### PR TITLE
Find meeting times that include optional attendees and write the corresponding tests. 

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -25,7 +25,7 @@ public final class FindMeetingQuery {
    * finds the times when the meeting could happen that day.
    * If one or more time slots exists so that both mandatory
    * and optional attendees can attend, return those time slots.
-   * Otherwise, return the tiem slots that fit just the mandatory attendees.
+   * Otherwise, return the time slots that fit just the mandatory attendees.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     // Create a list of the TimeRanges when all (optional and mandatory)

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -19,15 +19,18 @@ import java.util.Collection;
 import java.util.Collections;
 
 public final class FindMeetingQuery {
-
   /**
    * Given the meeting information,
    * finds the times when the meeting could happen that day.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    int startTime = 0;
+    int startTime = TimeRange.START_OF_DAY;
 
+    // The busy times for mandatory attendees.
     ArrayList<TimeRange> busyTimes = new ArrayList<>();
+    // The busy times for optional attendees.
+    ArrayList<TimeRange> busyTimesOptional = new ArrayList<>();
+
     for (Event event : events) {
       for (String attendee : request.getAttendees()) {
         if (event.getAttendees().contains(attendee)) {
@@ -35,10 +38,18 @@ public final class FindMeetingQuery {
           break;
         }
       }
+
+      for (String optionalAttendee : request.getOptionalAttendees()) {
+        if (event.getOptionalAttendees().contains(optionalAttendee)) {
+          busyTimesOptional.add(event.getWhen());
+          break;
+        }
+      }
     }
 
     ArrayList<TimeRange> freeTimes = new ArrayList<>();
     Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
+    Collections.sort(busyTimesOptional, TimeRange.ORDER_BY_START);
 
     for (TimeRange busy : busyTimes) {
       if (busy.start() - startTime >= request.getDuration()) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -79,6 +79,12 @@ public final class FindMeetingQuery {
       freeTimes.add(TimeRange.fromStartEnd(startTime, TimeRange.END_OF_DAY, /* inclusive */ true));
     }
 
+    // If there is at least one time where both mandatory
+    // and optional attendees can attend the meeting, return that list.
+    if (freeTimes.size() > 0) {
+      return freeTimes;
+    }
+
     // Repeat the exact same search, but this time find meetings
     // that only mandatory attendees can attend.
     startTime = TimeRange.START_OF_DAY;
@@ -102,12 +108,6 @@ public final class FindMeetingQuery {
         freeTimesMandatory.add(
             TimeRange.fromStartEnd(startTime, TimeRange.END_OF_DAY, /* inclusive */ true));
       }
-    }
-
-    // If there is at least one time where both mandatory
-    // and optional attendees can attend the meeting, return that list.
-    if (freeTimes.size() > 0) {
-      return freeTimes;
     }
 
     return freeTimesMandatory;

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -140,8 +140,7 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)),
         new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_B)),
-        new Event("Event 3",
-            TimeRange.fromStartDuration(TimeRange.START_OF_DAY, DURATION_DAY),
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, DURATION_DAY),
             Arrays.asList(PERSON_C)));
 
     MeetingRequest request =

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -189,7 +189,8 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void overlappingEvents() {
-    // Have an event for each person, but have their events overlap. We should only see two options.
+    // Have an event for each person, but have their events overlap.
+    // We should only see two options.
     //
     // Events  :       |--A--|
     //                     |--B--|
@@ -215,8 +216,8 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void nestedEvents() {
-    // Have an event for each person, but have one person's event fully contain another's event. We
-    // should see two options.
+    // Have an event for each person, but have one person's event fully contain another's event.
+    // We should see two options.
     //
     // Events  :       |----A----|
     //                   |--B--|
@@ -377,10 +378,10 @@ public final class FindMeetingQueryTest {
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_1000AM, TIME_1100AM, true),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_1000AM, TIME_1100AM, false),
             Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_60_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
@@ -406,7 +407,7 @@ public final class FindMeetingQueryTest {
         new Event("Event 2", TimeRange.fromStartEnd(TIME_0830AM, TimeRange.END_OF_DAY, true),
             Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_60_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -285,6 +285,7 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -381,6 +382,8 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
@@ -405,6 +408,8 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();


### PR DESCRIPTION
If one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots. Otherwise, return the time slots that fit just the mandatory attendees.

The approach is now just to take the previous algorithm (only for mandatory attendees) and run it for both mandatory and optional attendees as well. If the size of that list is greater than zero (meaning that there are times where optional attendees can attend a meeting), then return those times. 